### PR TITLE
Styles should not contain undefined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,7 @@ class EnergyEntityRow extends SubscribeMixin(LitElement) {
   static get styles() {
     return [
       (customElements.get("hui-sensor-entity-row") as any)?.styles,
-    ];
+    ].filter(e => e !== undefined && e !== null);
   }
 }
 


### PR DESCRIPTION
This fixes the row breaking with Home Assistant 2024.12 (Issue #3)

![image](https://github.com/user-attachments/assets/26b854ec-0e51-4b7d-b378-94ef272e5cee)

Beware though:
I am not quite sure though if this isn't just "solving" symptoms instead of the underlying actual cause.

But to determine that I'd first have to know:
Why does it access `hui-sensor-entity-row` and how could one test if with this fix, whatever that is for still works?

![image](https://github.com/user-attachments/assets/d6f7ef34-2896-49be-9c75-cabbc889c239)

It does still exist at least